### PR TITLE
Using new apache beam version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 
 ## Version Info
 
-- Apache Beam: 2.1.0
+- Apache Beam: 2.20.0
 - Kuromoji: 0.7.7
 
 ## How to Use

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.1.0</beam.version>
+    <beam.version>2.20.0</beam.version>
 
-    <bigquery.version>v2-rev295-1.22.0</bigquery.version>
-    <google-clients.version>1.22.0</google-clients.version>
-    <guava.version>20.0</guava.version>
+    <bigquery.version>v2-rev459-1.25.0</bigquery.version>
+    <google-clients.version>1.30.0</google-clients.version>
+    <guava.version>29.0-jre</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.8.9</jackson.version>
     <joda.version>2.4</joda.version>


### PR DESCRIPTION
This pull request updated apache beam and its dependent packages version. This is because the current apache beam version used in kuromoji-for-bigquery is deprecated.

ref: https://cloud.google.com/dataflow/docs/support/sdk-version-support-status?hl=ja#apache-beam-sdks-2x
