### PR TITLE
Replace the deprecated method to read BigQuery table

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 mvn clean package
 
 # Run bigquery-to-datastore via the compiled JAR file
-java -cp $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.0.jar \
+java -cp $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.1.jar \
   com.github.yuiskw.beam.Kuromoji4BigQuery \
   --project=test-project-id
   --schema=id:integer
@@ -70,6 +70,12 @@ java -cp $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.0.jar \
   --maxNumWorkers=10 \
   --workerMachineType=n1-standard-2
 ```
+
+## Versions
+|kuromoji-for-bigquery|Apache Beam|kuromoji|
+|---------------------|-----------|--------|
+|0.1.0                |2.1.0      |0.7.7   |
+|0.2.x                |2.20.0     |0.7.7   |
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>com.github.yuiskw</groupId>
   <artifactId>kuromoji-for-bigquery</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
 
   <packaging>jar</packaging>
 

--- a/src/test/java/com/github/yuiskw/beam/Kuromoji4BigQueryTest.java
+++ b/src/test/java/com/github/yuiskw/beam/Kuromoji4BigQueryTest.java
@@ -3,10 +3,10 @@
  */
 package com.github.yuiskw.beam;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -78,6 +78,28 @@ public class Kuromoji4BigQueryTest {
     assertEquals("integer", parents.get("id"));
     assertEquals("string", parents.get("name"));
     assertEquals("float", parents.get("height"));
+  }
+
+  @Test
+  public void testGetSelectedFields1() {
+    String tokenizedColumn = "text";
+    LinkedHashMap<String, String> schemaMap = new LinkedHashMap<String, String>();
+    schemaMap.put("x", "interger");
+    schemaMap.put("y", "string");
+    List<String> selectedFields = Kuromoji4BigQuery.getSelectedFields(schemaMap, tokenizedColumn);
+    List<String> expected = Arrays.asList("x", "y", "text");
+    assertEquals(selectedFields, expected);
+  }
+
+  @Test
+  public void testGetSelectedFields2() {
+    String tokenizedColumn = "text";
+    LinkedHashMap<String, String> schemaMap = new LinkedHashMap<String, String>();
+    schemaMap.put("x", "interger");
+    schemaMap.put("text", "string");
+    List<String> selectedFields = Kuromoji4BigQuery.getSelectedFields(schemaMap, tokenizedColumn);
+    List<String> expected = Arrays.asList("x", "text");
+    assertEquals(selectedFields, expected);
   }
 
 

--- a/src/test/java/com/github/yuiskw/beam/Kuromoji4BigQueryTest.java
+++ b/src/test/java/com/github/yuiskw/beam/Kuromoji4BigQueryTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
## Overciew
By upgradeing Apache Beam to 2.20.0, the method to BigQuery table is deprecated. So, it would be great to use the latest manner. Moreover, `DIRECT_READ` method to the new BigQuery reader enables us to improve the performance to read.a table.