### PR TITLE
Add mainClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,28 +54,27 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 mvn clean package
 
 # Run bigquery-to-datastore via the compiled JAR file
-java -cp $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.1.jar \
-  com.github.yuiskw.beam.Kuromoji4BigQuery \
-  --project=test-project-id
-  --schema=id:integer
-  --inputDataset=test_input_dataset
-  --inputTable=test_input_table
-  --outputDataset=test_output_dataset
-  --outputTable=test_output_table
-  --tokenizedColumn=text
-  --outputColumn=token
-  --kuromojiMode=NORMAL
-  --tempLocation=gs://test_yu/test-log/
-  --gcpTempLocation=gs://test_yu/test-log/
+java -jar $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.2.jar \
+  --project=test-project-id \
+  --schema=id:integer \
+  --inputDataset=test_input_dataset \
+  --inputTable=test_input_table \
+  --outputDataset=test_output_dataset \
+  --outputTable=test_output_table \
+  --tokenizedColumn=text \
+  --outputColumn=token \
+  --kuromojiMode=NORMAL \
+  --tempLocation=gs://test_yu/test-log/ \
+  --gcpTempLocation=gs://test_yu/test-log/ \
   --maxNumWorkers=10 \
   --workerMachineType=n1-standard-2
 ```
 
 ## Versions
-|kuromoji-for-bigquery|Apache Beam|kuromoji|
-|---------------------|-----------|--------|
-|0.1.0                |2.1.0      |0.7.7   |
-|0.2.x                |2.20.0     |0.7.7   |
+| kuromoji-for-bigquery | Apache Beam | kuromoji |
+| --------------------- | ----------- | -------- |
+| 0.1.0                 | 2.1.0       | 0.7.7    |
+| 0.2.x                 | 2.20.0      | 0.7.7    |
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.github.yuiskw.beam.Kuromoji4BigQuery</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
       </plugin>
 
       <!--

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>com.github.yuiskw</groupId>
   <artifactId>kuromoji-for-bigquery</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
 
   <packaging>jar</packaging>
 


### PR DESCRIPTION
ref: https://beam.apache.org/documentation/runners/dataflow/#self-executing-jar

In some cases, such as starting a pipeline using a scheduler such as Apache AirFlow, a self-executing JAR is needed.
In this PR, I made it possible to run kuromoji-for-bigquery from Apache airflow by setting Kuromoji4Bigquery class to mainClass.
When mainClass is set, kuromoji-for-bigquery is executed as follows:

```
java -jar target/kuromoji-for-bigquery-bundled-0.2.1.jar \
--project=<project> \
--inputDataset=<input_dataset> \
--inputTable=<input_table> \
--schema=<schema> \
--outputDataset=<output_dataset> \
--outputTable=<output_table> \
--tokenizedColumn=<column> \
--outputColumn=token \
--tempLocation=<gs_path> \
--gcpTempLocation=<gs_path> \
--runner=DataflowRunner 
```