### PR TITLE
Use Apache Beam 2.34.0 to workaround CVE-2021-44228

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 
 ## Version Info
 
-- Apache Beam: 2.20.0
+- Apache Beam: 2.34.0
 - Kuromoji: 0.7.7
 
 ## How to Use
@@ -75,6 +75,7 @@ java -jar $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.2.jar \
 | --------------------- | ----------- | -------- |
 | 0.1.0                 | 2.1.0       | 0.7.7    |
 | 0.2.x                 | 2.20.0      | 0.7.7    |
+| 0.3.x                 | 2.34.0      | 0.7.7    |
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,16 @@
 
   <groupId>com.github.yuiskw</groupId>
   <artifactId>kuromoji-for-bigquery</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
 
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.20.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <bigquery.version>v2-rev459-1.25.0</bigquery.version>
-    <google-clients.version>1.30.0</google-clients.version>
+    <google-api-client.version>1.32.2</google-api-client.version>
+    <google-http-client.version>1.40.1</google-http-client.version>
     <guava.version>29.0-jre</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.8.9</jackson.version>
@@ -254,7 +255,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>${google-clients.version}</version>
+      <version>${google-api-client.version}</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled
              in by a transitive dependency of google-api-client -->
@@ -282,7 +283,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>${google-clients.version}</version>
+      <version>${google-http-client.version}</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled
              in by a transitive dependency of google-api-client -->


### PR DESCRIPTION
Hello!

This pull request updates the version of Apache Beam it depends on to 2.34.0.

I updated the kuromoji-for-bigquery version to 0.3.0 because it seemed to change the minor version depending on the Beam version used, but please let me know if you have a different policy.

## background

Currently, kuromoji-for-bigquery depends on Beam 2.20.0, but according to an email I received from Google, Beam version 2.31.0 or earlier is affected by CVE-2021-44228 and it is strongly recommended to update it immediately.

Also, on Cloud Dataflow, [Beam 2.20.0 has already been deprecated on April 15, 2021](https://cloud.google.com/dataflow/docs/support/sdk-version-support-status?hl=ja#apache-beam-sdks-2x) (Cloud Dataflow console warns that it will suddenly become unusable in the future).

In addition, I used [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/) to check that kuromoji-for-bigquery itself has no dependency on log4j2.