### PR TITLE
Use Apache Beam 2.42.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 
 ## Version Info
 
-- Apache Beam: 2.34.0
+- Apache Beam: 2.42.0
 - Kuromoji: 0.7.7
 
 ## How to Use
@@ -54,7 +54,7 @@ It is horizontally-scalable on top of distributed system, since apache beam can 
 mvn clean package
 
 # Run bigquery-to-datastore via the compiled JAR file
-java -jar $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.2.jar \
+java -jar $(pwd)/target/kuromoji-for-bigquery-bundled-0.4.0.jar \
   --project=test-project-id \
   --schema=id:integer \
   --inputDataset=test_input_dataset \
@@ -76,6 +76,7 @@ java -jar $(pwd)/target/kuromoji-for-bigquery-bundled-0.2.2.jar \
 | 0.1.0                 | 2.1.0       | 0.7.7    |
 | 0.2.x                 | 2.20.0      | 0.7.7    |
 | 0.3.x                 | 2.34.0      | 0.7.7    |
+| 0.4.x                 | 2.42.0      | 0.7.7    |
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 
   <groupId>com.github.yuiskw</groupId>
   <artifactId>kuromoji-for-bigquery</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
 
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.39.0</beam.version>
+    <beam.version>2.42.0</beam.version>
 
     <bigquery.version>v2-rev459-1.25.0</bigquery.version>
     <google-api-client.version>1.33.0</google-api-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -361,8 +361,8 @@
       <groupId>org.atilika.kuromoji</groupId>
       <artifactId>kuromoji</artifactId>
       <version>0.7.7</version>
-      <type>jar</type>
-      <scope>compile</scope>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/lib/kuromoji-0.7.7.jar</systemPath>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### Summary
The current latest version, kuromoji-for-bigquery 0.3.0 uses Beam 2.34.0.
However, [Beam 2.34.0 will be deprecated on November 11, 2022](https://cloud.google.com/dataflow/docs/support/sdk-version-support-status).

This pull request updates the Apache Beam version to 2.42.0. (latest version)
I updated version of kuromoji-for-bigquery to 0.4.0, as the minor version seems to change depending on the version of Beam used.

---

I found that [kuromoji 0.7.7 is no longer provided](https://mvnrepository.com/artifact/org.atilika.kuromoji/kuromoji/0.7.7).
So this pull request adds [kuromoji 0.7.7 built from source code](https://github.com/atilika/kuromoji/releases/tag/0.7.7).
