### PR TITLE
Run unit tests on GitHub Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,38 @@
+name: Unit testing
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - java_distribution: "zulu"
+            java_version: "8"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "${{ matrix.java_distribution }}"
+          java-version: "${{ matrix.java_version }}"
+          cache: 'maven'
+      - name: checkstyle
+        run: |
+          mvn checkstyle:checkstyle
+      - name: test compile
+        run: |
+          mvn compile
+      - name: Run unit tests
+        run: |
+          mvn test
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - java_distribution: "zulu"
-            java_version: "8"
+            java_version: "11"
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Overview
We used to use TravisCI to run unit tests, as I wasn't just familiar with GitHub Actions at the time of initially create the repository. However, because of the lack of visibility of TravisCI results on a pull request, we run unit tests on GitHub Actions.